### PR TITLE
[idea] Allow clients to specify custom filenames

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -11,19 +11,27 @@ const shared = {
       let msgspec = srvmodel.msg[msg]
       if(msgspec.async) {
         seneca.add(msg, (msg,reply)=>reply())
-        seneca.sub(msg, reload(shared.actpath(msg), {options}))
+        seneca.sub(msg, reload(shared.actpath(msg, msgspec), {options}))
       }
       else {
-        seneca.message(msg, reload(shared.actpath(msg), {options}))
+        seneca.message(msg, reload(shared.actpath(msg, msgspec), {options}))
       }
     }
   },
 
-  actpath(msg) {
-    let pairs = msg.split(/\s*,\s*/)
+  actpath(msg, spec = {}) {
+    const localpath = path => './' + path
+
+    if (spec.filename) {
+      return localpath(spec.filename)
+    }
+
+    const pairs = msg.split(/\s*,\s*/)
 
     // TODO: maybe take more than just the last one!
-    let path = './'+pairs[pairs.length-1].replace(/:/g,'_')
+    //
+    const path = localpath(pairs[pairs.length - 1].replace(/:/g,'_'))
+
     return path
   },
 }


### PR DESCRIPTION
The `filename` option is optional.

```
main: srv: downloader: {
  msg: {
    'role:info,source:npm,need:pkg': {
      async: true,
      filename: 'need_npm_pkg.js'
    }

    'role:info,source:github,need:pkg': {
      async: true,
      filename: 'need_github_pkg.js'
    }
  }
}
```
